### PR TITLE
upgrade node 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "engines": {
-    "node": "^18.17.0"
+    "node": "^22.2.0"
   },
   "workspaces": [
     "reuse",
@@ -42,7 +42,7 @@
     "dayjs": "^1.11.11"
   },
   "volta": {
-    "node": "18.17.1"
+    "node": "22.2.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-darwin-arm64": "^4.17.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "include": ["./**/*.ts"],
   "compilerOptions": {
-    "lib": ["ESNext"],
-    "module": "ESNext",
-    "moduleResolution": "nodenext",
+    "lib": ["ESNext", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
- npm run (build|dev|export)などが失敗する。

```log
> dev
> ts-node "./scripts/runWorkspace.ts" --command=dev

(node:75101) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /*****/*****/*****/slide/scripts/runWorkspace.ts
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:176:9)
    at defaultGetFormat (node:internal/modules/esm/get_format:219:36)
    at defaultLoad (node:internal/modules/esm/load:133:22)
    at async nextLoad (node:internal/modules/esm/hooks:791:22)
    at async nextLoad (node:internal/modules/esm/hooks:791:22)
    at async Hooks.load (node:internal/modules/esm/hooks:383:20)
    at async MessagePort.handleMessage (node:internal/modules/esm/worker:255:18) {
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
}
```